### PR TITLE
Sliver detectie en slivers oplossen

### DIFF
--- a/src/site/apt/releasenotes.apt.vm
+++ b/src/site/apt/releasenotes.apt.vm
@@ -20,13 +20,30 @@ ${project.name} ${project.version} Release Notes
   De complete lijst met issues voor deze release is beschikbaar in de tracker:
   {{{${project.issueManagement.url}?q=milestone%3A${project.version}+is%3Aclosed}milestone ${project.version} issues}}.
   
-  Releases zijn beschikbaar op: {{{https://github.com/B3Partners/flamingo-ibis/releases/}github releases}}, snapshots 
+  Releases zijn beschikbaar op: {{{https://github.com/B3Partners/flamingo-ibis/releases/}github releases}}, de laatste snapshots 
   zijn beschikbaar in de {{{http://repo.b3p.nl/nexus/#nexus-search;gav~~ibis-dist~~~}Maven repository}}.
 
-~~** Nieuw
+** Nieuw
 
-~~  * Gebruik Flamingo versie ${project.properties.get("flamingo.version")}, zie ook:
-~~    {{{https://github.com/flamingo-geocms/flamingo/releases/tag/v${project.properties.get("flamingo.version")}Flamingo release notes}}
+  * Gebruik Flamingo versie ${project.properties.get("flamingo.version")}, zie ook:
+    {{{https://github.com/flamingo-geocms/flamingo/releases/tag/v${project.properties.get("flamingo.version")}}Flamingo release notes}}
+
+  []
+
+* Versie 2.10
+
+** Nieuw
+
+  * Gebruik Flamingo versie 4.7.7-rc1, zie ook:
+    {{{https://github.com/flamingo-geocms/flamingo/releases/tag/v4.7.7-rc1}Flamingo release notes}}
+
+  []
+
+** Verbeteringen en oplossingen
+
+  * Laden van applicatie vanuit bookmark verbeterd
+  
+  []
 
 * Versie 2.9
 

--- a/src/site/apt/releasenotes.apt.vm
+++ b/src/site/apt/releasenotes.apt.vm
@@ -28,6 +28,8 @@ ${project.name} ${project.version} Release Notes
   * Gebruik Flamingo versie ${project.properties.get("flamingo.version")}, zie ook:
     {{{https://github.com/flamingo-geocms/flamingo/releases/tag/v${project.properties.get("flamingo.version")}}Flamingo release notes}}
 
+  * configureerbare sliver detectie voor splitsen ({{{https://github.com/B3Partners/flamingo-ibis/pull/57}PR #57}})
+
   []
 
 * Versie 2.10
@@ -48,7 +50,7 @@ ${project.name} ${project.version} Release Notes
 * Versie 2.9
 
   De complete lijst met issues voor deze release is beschikbaar in de tracker:
-  {{{${project.issueManagement.url}?q=milestone%3A2.8+is%3Aclosed}milestone 2.8 issues}}.
+  {{{${project.issueManagement.url}?q=milestone%3A2.9+is%3Aclosed}milestone 2.9 issues}}.
 
 ** Verbeteringen en oplossingen
 

--- a/src/site/markdown/development.md
+++ b/src/site/markdown/development.md
@@ -24,8 +24,9 @@ This is required to publish the site into the gh-pages branch using the
 ## releasing
 
 Use the regular maven relase cycle; `mvn release:prepare` and then `mvn release:perform`.
+Upload the `dist` artifact to the github release.
 
 ## generating and deploying site
 
-`mvn site` will create a staged maven site, `mvn site site:deploy` should take
+`mvn site` will create a staged maven site, `mvn site site-deploy` should take
 care of deploying the site to https://b3partners.github.io/flamingo-ibis/.

--- a/viewer/src/main/webapp/viewer-html/ibis/IbisSplit-config.js
+++ b/viewer/src/main/webapp/viewer-html/ibis/IbisSplit-config.js
@@ -57,6 +57,28 @@ Ext.define("viewer.components.CustomConfiguration", {
                 displayField: 'label',
                 valueField: 'id',
                 value: me.configObject.workflowstatus ? me.configObject.workflowstatus : "bewerkt"
+            }, {
+                xtype: 'numberfield',
+                fieldLabel: 'Maximum oppervlakte voor een sliver',
+                labelWidth: this.labelWidth,
+                name: 'sliverMaxArea',
+                itemId: 'sliverMaxArea',
+                value: me.configObject.sliverMaxArea ? me.configObject.sliverMaxArea : 100,
+                minValue: 0,
+                maxValue: 1000,
+                step: 1
+            }
+            , {
+                xtype: 'numberfield',
+                fieldLabel: 'Thinness ratio (cirkel heeft ratio 1, polygoon heeft ratio =< 1, 0 betekent overslaan)',
+                // https://books.google.se/books?hl=sv&id=uGWmR0f_350C&q=thinness#v=onepage&q=thinness&f=false
+                labelWidth: this.labelWidth,
+                name: 'sliverRatio',
+                itemId: 'sliverRatio',
+                value: me.configObject.sliverRatio ? me.configObject.sliverRatio : 0,
+                minValue: 0,
+                maxValue: 1,
+                step: 0.02
             }
         ]);
     }

--- a/viewer/src/main/webapp/viewer-html/ibis/IbisSplit.js
+++ b/viewer/src/main/webapp/viewer-html/ibis/IbisSplit.js
@@ -24,8 +24,10 @@ Ext.define("viewer.components.IbisSplit", {
     config: {
         // custom url
         actionbeanUrl: "/viewer/action/feature/ibissplit",
-        // always "definitief" for split
-        workflowstatus: "definitief"
+        // always "bewerkt" for split
+        workflowstatus: "bewerkt",
+        sliverRatio: 0,
+        sliverMaxArea: 100
     },
     /** (cached) workflow status. */
     status: null,
@@ -56,6 +58,8 @@ Ext.define("viewer.components.IbisSplit", {
         var obj = {};
         obj[workflowFieldName] = this.status.get("id");
         obj[mutatiedatumFieldName] = this.maincontainer.getComponent(mutatiedatumFieldName).getValue();
+        obj['sliverRatio'] = this.config.sliverRatio;
+        obj['sliverMaxArea'] = this.config.sliverMaxArea;
         // reden veld ontbreekt in datamodel! en terreinen kunnen niet gesplitst worden
         // obj[redenFieldName] = 'splitsing';
         return Ext.util.JSON.encode(obj);


### PR DESCRIPTION
voegt een tweetal configuratie opties toe:
  - Maximum oppervlakte voor een sliver: alleen geometrieën die kleiner zijn worden als mogelijke sliver bekeken
  - Thinness ratio: (een cirkel heeft waarde 1, polygonen een waarde =< 1, 0 betekent overslaan van sliveroplossen), waarden zo rond de 0.3 voor thinness ration lijken goed te zijn. voor meer info over het algoritme: [Microscope Image Processing](https://books.google.se/books?hl=sv&id=uGWmR0f_350C&q=thinness#v=onepage&q=thinness&f=false)


close #56 