### PR TITLE
Voeg een kolom toe met de 'Definitief' gegevens

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,10 +11,10 @@
     <parent>
         <groupId>org.flamingo-mc</groupId>
         <artifactId>flamingo-mc</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.1-SNAPSHOT</version>
     </parent>
     <properties>
-        <flamingo.version>4.8.0</flamingo.version>
+        <flamingo.version>4.8.1-SNAPSHOT</flamingo.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <!-- voor een deploment op ibis.b3p.nl gebruik je -Dibis-flamingo-ds-name=geo_viewer-ibis 

--- a/src/site/apt/releasenotes.apt.vm
+++ b/src/site/apt/releasenotes.apt.vm
@@ -34,6 +34,7 @@ ${project.name} ${project.version} Release Notes
 
   * Terugdraaien van de aanpassing om ontstaan van meer dan 1 archiefrecord van een object per mutatiedatum te voorkomen ({{{https://github.com/B3Partners/flamingo-ibis/issues/60}#60}}, {{{https://github.com/B3Partners/flamingo-ibis/issues/67}#67}})
 
+  * Weergave van "Defintief" object in geval van "Bewerkt" object dat bewerkt of geaccordeerd wordt. ({{{https://github.com/B3Partners/flamingo-ibis/issues/61}#61}})
   []
 
 

--- a/src/site/apt/releasenotes.apt.vm
+++ b/src/site/apt/releasenotes.apt.vm
@@ -25,7 +25,8 @@ ${project.name} ${project.version} Release Notes
 
 ** Nieuw
 
-  * ...
+  * Gebruik Flamingo versie 4.8.1-SNAPSHOT, zie ook:
+    {{{https://github.com/flamingo-geocms/flamingo/releases/tag/v4.8.1}Flamingo release notes}}
 
   []
 
@@ -35,6 +36,7 @@ ${project.name} ${project.version} Release Notes
   * Terugdraaien van de aanpassing om ontstaan van meer dan 1 archiefrecord van een object per mutatiedatum te voorkomen ({{{https://github.com/B3Partners/flamingo-ibis/issues/60}#60}}, {{{https://github.com/B3Partners/flamingo-ibis/issues/67}#67}})
 
   * Weergave van "Defintief" object in geval van "Bewerkt" object dat bewerkt of geaccordeerd wordt. ({{{https://github.com/B3Partners/flamingo-ibis/issues/61}#61}})
+
   []
 
 
@@ -50,13 +52,13 @@ ${project.name} ${project.version} Release Notes
 
 ** Verbeteringen en oplossingen
 
-  * undo/redo/cancel voor tekenen in edit/teken/splits component ({{{https://github.com/flamingo-geocms/flamingo/pull/782}Flamingo #782}})
+  * Undo/redo/cancel voor tekenen in edit/teken/splits component ({{{https://github.com/flamingo-geocms/flamingo/pull/782}Flamingo #782}})
 
   * Voorkom ontstaan van meer dan 1 archiefrecord van een object per mutatiedatum ({{{https://github.com/B3Partners/flamingo-ibis/issues/60}#60}})
 
-  * factsheet uitbreidingen ({{{https://github.com/B3Partners/flamingo-ibis/issues/62}#62}})
+  * Factsheet uitbreidingen ({{{https://github.com/B3Partners/flamingo-ibis/issues/62}#62}})
 
-  * verbetering in oplossing van pseudo-self-intersects en gaten van terreinen door splits artifacten ({{{https://github.com/B3Partners/flamingo-ibis/issues/64}#64}})
+  * Verbetering in oplossing van pseudo-self-intersects en gaten van terreinen door splits artifacten ({{{https://github.com/B3Partners/flamingo-ibis/issues/64}#64}})
 
   []
 

--- a/viewer/src/main/webapp/WEB-INF/classes/log4j.properties
+++ b/viewer/src/main/webapp/WEB-INF/classes/log4j.properties
@@ -3,7 +3,7 @@ logFile=ibis-geo-viewer.log
 
 log4j.rootLogger=INFO,file
 
-log4j.logger.nl.b3p=DEBUG
+log4j.logger.nl.b3p=INFO
 
 # Set to INFO or DEBUG to view more information about loading components
 log4j.logger.nl.b3p.viewer.components=INFO

--- a/viewer/src/main/webapp/viewer-html/ibis/IbisEdit-config.js
+++ b/viewer/src/main/webapp/viewer-html/ibis/IbisEdit-config.js
@@ -54,6 +54,13 @@ Ext.define("viewer.components.CustomConfiguration", {
                 labelWidth: this.labelWidth
             },
             {
+                xtype: 'checkbox',
+                fieldLabel: 'Vorige -Definitief- versie ophalen',
+                name: 'showVorigeDefintiefVersie',
+                value: this.configObject.showVorigeDefintiefVersie !== undefined ? this.configObject.showVorigeDefintiefVersie : false,
+                labelWidth: this.labelWidth
+            },
+            {
                 itemId: 'prefixLabels',
                 xtype: 'panel',
                 collapsible: true,

--- a/viewer/src/main/webapp/viewer-html/ibis/IbisEdit.js
+++ b/viewer/src/main/webapp/viewer-html/ibis/IbisEdit.js
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
- * Ibis Edit component
+ * Ibis Edit component.
  * @author mprins
  */
 Ext.define("viewer.components.IbisEdit", {
@@ -25,7 +25,8 @@ Ext.define("viewer.components.IbisEdit", {
     tabbedFormPanels: {},
     addedTabPanels: [],
     config: {
-        prefixConfig: []
+        prefixConfig: [],
+        showVorigeDefintiefVersie: false
     },
     newID: null,
     /**
@@ -53,6 +54,7 @@ Ext.define("viewer.components.IbisEdit", {
                 text: '',
                 xtype: "label"}
         ]);
+        console.debug("showVorigeDefintiefVersie is: ", this.config.showVorigeDefintiefVersie);
 
         return this;
     },

--- a/viewer/src/main/webapp/viewer-html/ibis/IbisEdit.js
+++ b/viewer/src/main/webapp/viewer-html/ibis/IbisEdit.js
@@ -221,21 +221,23 @@ Ext.define("viewer.components.IbisEdit", {
                             var lbl = Ext.get(property + '_def');
                             var f = me.inputContainer.getForm().findField(property);
                             if (lbl) {
-                                if (property === me.workflow_fieldname) {
-                                    lbl.setHtml(me.workflowStore.getById(value).get("label"));
-                                } else {
-                                    if (f && f.getValue() != value) {
-                                        if (f.getXType() === "datefield") {
-                                            value = Ext.Date.format(Ext.Date.parse(value, 'd-m-Y H:i:s'), f.format);
-                                        }
-                                        // afwijkende waarde markeren met bold font
+                                if (f) {
+                                    var defVal = f.getValue();
+                                    if (property === me.workflow_fieldname) {
+                                        value = me.workflowStore.getById(value).get("label");
+                                    }
+                                    if (f.getXType() === "datefield") {
+                                        value = Ext.Date.format(Ext.Date.parse(value, 'd-m-Y H:i:s'), f.format);
+                                        defVal = Ext.Date.format(defVal, f.format);
+                                    }
+                                    if (defVal != value) {
+                                        // afwijkende waarde markeren
                                         lbl.setHtml('<span class="def_verschillend">' + value + '</span>');
                                         lbl.setBorder(1);
                                     } else {
                                         lbl.setHtml('<span class="def_identiek">' + value + '</span>');
                                     }
                                 }
-                                lbl.setHeight(null);
                             }
                         });
                         me.geomlabel.setText("De rechter kolom bevat de 'Definitieve' waarden.");

--- a/viewer/src/main/webapp/viewer-html/ibis/IbisEdit.js
+++ b/viewer/src/main/webapp/viewer-html/ibis/IbisEdit.js
@@ -197,7 +197,8 @@ Ext.define("viewer.components.IbisEdit", {
             var wf = feature[this.workflow_fieldname] || 'bewerkt';
             s = this.workflowStore.getById(wf).get("label");
         }
-        if (this.config.showVorigeDefintiefVersie && feature[this.workflow_fieldname] && feature[this.workflow_fieldname] === "bewerkt") {
+        if (this.config.showVorigeDefintiefVersie && feature[this.workflow_fieldname] &&
+                (feature[this.workflow_fieldname] === "bewerkt" || feature[this.workflow_fieldname] === "definitief")) {
             // get kavel/terrein voor ibis_id/definitief
             this.getDefinitiefFeature(feature);
         }
@@ -207,7 +208,7 @@ Ext.define("viewer.components.IbisEdit", {
         var options = {
             arrays: 0,
             featureType: bewerktFeature.id,
-            filter: "ibis_id=" + bewerktFeature.ibis_id + " AND workflow_status='definitief'",
+            filter: "ibis_id=" + bewerktFeature[idFieldName] + " AND workflow_status='definitief'",
             limit: 1,
             page: 1,
             start: 0


### PR DESCRIPTION
Er zijn 3 extra css klassen beschikbaar om weergave te tunen:

- `def_container`: voor de container van de waarde
- `def_verschillend`: voor waarden die niet gelijk zijn gebleven tussen "Bewerkt" en "Definitief"
- `def_identiek`: voor waarden die gelijk zijn gebleven tussen "Bewerkt" en "Definitief"


close #61 