### PR TITLE
Fixes JS error after saving

### DIFF
--- a/viewer/src/main/webapp/viewer-html/ibis/IbisEdit.js
+++ b/viewer/src/main/webapp/viewer-html/ibis/IbisEdit.js
@@ -487,8 +487,9 @@ Ext.define("viewer.components.IbisEdit", {
         var me = this;
         Ext.Object.eachValue(this.config.viewerController.app.appLayers, function (appLayer) {
             // alle aangevinkte lagen verversen
-            if (me.config.viewerController.getLayerChecked(appLayer)) {
-                me.config.viewerController.getLayer(appLayer).reload();
+            var layer = me.config.viewerController.getLayer(appLayer);
+            if (layer && me.config.viewerController.getLayerChecked(appLayer)) {
+                layer.reload();
             }
         });
         this.currentFID = fid;


### PR DESCRIPTION
Because of the issue, layers where not reloaded and popup was not closed.

Cause & fix:
Some applayers are not available as layer (because of mashup). Check if layer exists before reloading.