### PR TITLE
bewerken kavels van afgevoerd terrein

### DIFF
--- a/src/site/apt/releasenotes.apt.vm
+++ b/src/site/apt/releasenotes.apt.vm
@@ -55,6 +55,8 @@ ${project.name} ${project.version} Release Notes
 
   * IBPV-201: mutatie van een gemeente weggooien zonder deze te bewerken  ({{{https://github.com/B3Partners/flamingo-ibis/issues/144}#144}})
 
+  * IBPV-052: Kavels muteren terwijl een terrein op afgevoerd staat ({{{https://github.com/B3Partners/flamingo-ibis/issues/140}#140}})
+
   []
 
 


### PR DESCRIPTION
Als een terrein status afgevoerd heeft, maar de kavel nog bewerkt of definitief dan terrein herstellen op basis van laatste versie. Per definitie is de laatste versie het terrein met status afgevoerd.

close #140