### PR TITLE
reduceer minimum password lengte naar 8

### DIFF
--- a/viewer-admin/src/main/webapp/WEB-INF/web.xml
+++ b/viewer-admin/src/main/webapp/WEB-INF/web.xml
@@ -103,7 +103,7 @@
     <context-param>
         <description>minimum length of password</description>
         <param-name>password.length</param-name>
-        <param-value>12</param-value>
+        <param-value>8</param-value>
     </context-param>
     <context-param>
         <description>


### PR DESCRIPTION
De default wachtwoord lengte is 12 karakters aangezien dat de aanbeveling van KPN RED team is na verschillende PEN tests van Flamingo.

zie ook flamingo-geocms/flamingo#1656 en https://github.com/flamingo-geocms/flamingo/pull/1658 en mantis-15445